### PR TITLE
Add info where to find the compiled documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Configure and build from the git top dir like so:
     cd build
     make
 
+After a successfull build you can find the documentation in `build/docs/html/`
+if you open the `index.html` in your browser you will see the entry point.
 
 # License and Copyright
 Copyright (C) Pelagicore AB 2017


### PR DESCRIPTION
The README didn't explain where one can find the documentation
after it has been compiled. This commit adds that information.