### PR TITLE
Add platform developer entry point

### DIFF
--- a/docs/chapters/baseplatform/index.rst
+++ b/docs/chapters/baseplatform/index.rst
@@ -1,0 +1,12 @@
+Base Platform
+*************
+
+PELUX as a platform is compiled from a lot of different projects with help of Yocto_. In the long run a platform developer will need to get comfortable reading `their documentation`_ but it should be enough to read the chapters here to get started.
+
+.. _Yocto: http://yoctoproject.org/
+.. _`their documentation`: https://www.yoctoproject.org/documentation
+
+.. include:: prerequisites.rst
+.. include:: using-the-repo-tool.rst
+.. include:: obtaining-a-PELUX-release.rst
+

--- a/docs/chapters/baseplatform/obtaining-a-PELUX-release.rst
+++ b/docs/chapters/baseplatform/obtaining-a-PELUX-release.rst
@@ -1,0 +1,33 @@
+Obtaining a PELUX release
+=========================
+
+The following manifests can be used for a build:
+
+* `pelux-intel.xml` - For building the `core-image-pelux` image for Intel
+* `pelux-intel-qt.xml` - For building the `core-image-pelux-qt` image, which is the baseline with QtAS
+* `pelux-rpi.xml` - For building the `core-image-pelux` image for Raspberry Pi 3
+
+Variables:
+
+* Manifest, refers to what `<manifest-name>.xml` file you want to use, for example `pelux-intel.xml`. Each hardware platform targeted by the PELUX reference has its own manifest describing what other git repositories are needed for the build.
+* Image, refers to what version of PELUX should be built. Currently there are two versions: `core-image-pelux` and `core-image-pelux-qt`. The latter being a version that includes QtAS_ components that enable the NeptuneUI demo application.
+
+Create a directory for the PELUX build. Instruct repo tool to fetch a manifest using the command `repo init`. In this context, branch denotes what branch of git repo `pelux-manifests` to use. Then make repo tool fetch all sources using the command `repo sync`.
+
+.. literalinclude:: snippets/repo-init.sh
+    :language: bash
+
+When done fetching the sources, create a build directory and set up bitbake. TEMPLATECONF tells the `oe-init-build-env` script which path to fetch configuration samples from. Note that the example below get the template configuration for the Intel BSP, adapt the path according to your current BSP.
+
+.. literalinclude:: snippets/repo-source.sh
+    :language: bash
+
+The script will create configs if there are no configs present, a message about created `conf/local.conf` and `conf/bblayers.conf` files is normal.
+
+
+Finally, build the desired image. See the variables description above for information on the different images.
+
+.. literalinclude:: snippets/bitbake.sh
+    :language: bash
+
+.. _QtAS: https://www.qt.io/qt-automotive-suite/

--- a/docs/chapters/baseplatform/prerequisites.rst
+++ b/docs/chapters/baseplatform/prerequisites.rst
@@ -1,0 +1,24 @@
+Prerequisites for building PELUX
+================================
+
+The following packages must be installed in order to build PELUX from source:
+
+.. code-block:: bash
+
+    git sed wget cvs subversion git-core coreutils unzip gawk python-pysqlite2
+    diffstat help2man make gcc build-essential g++ chrpath libxml2-utils
+    libsdl1.2-dev texinfo python3
+
+Dependencies for Debian users
+-----------------------------
+
+On Debian-based systems, the following command can be used to install these dependencies:
+
+.. code-block:: bash
+
+    $ apt-get update
+    $ apt-get install git sed wget cvs subversion git-core coreutils unzip gawk
+    python-pysqlite2 diffstat help2man make gcc build-essential g++ chrpath
+    libxml2-utils libsdl1.2-dev texinfo python3
+
+In addition to these tools, the `repo` tool must also be installed, this is covered in :ref:`using-the-repo-tool`.

--- a/docs/chapters/baseplatform/snippets/bitbake.sh
+++ b/docs/chapters/baseplatform/snippets/bitbake.sh
@@ -1,0 +1,1 @@
+bitbake <image>

--- a/docs/chapters/baseplatform/snippets/curl.sh
+++ b/docs/chapters/baseplatform/snippets/curl.sh
@@ -1,0 +1,3 @@
+curl https://storage.googleapis.com/git-repo-downloads/repo > \
+    ~/bin/repo
+chmod a+x ~/bin/repo

--- a/docs/chapters/baseplatform/snippets/export.sh
+++ b/docs/chapters/baseplatform/snippets/export.sh
@@ -1,0 +1,3 @@
+mkdir ~/bin
+echo "export PATH=~/bin/:$PATH" >> ~/.bashrc
+bash # needed to reload the ~/.bashrc

--- a/docs/chapters/baseplatform/snippets/manifest.xml
+++ b/docs/chapters/baseplatform/snippets/manifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <!-- Define remotes -->
+    <remote fetch="git://git.yoctoproject.org" name="yocto"/>
+    <remote fetch="ssh://git@github.com/Pelagicore/" name="github"/>
+
+    <!-- Specify layers -->
+    <project remote="yocto"
+             revision="master"
+             name="poky"
+             path="sources/poky"/>
+
+    <project remote="github"
+             revision="9ac8ad53a22649f84938b4625592f3ef9a4d30f4"
+             name="meta-bistro.git"
+             path="sources/meta-bistro"/>
+</manifest>

--- a/docs/chapters/baseplatform/snippets/repo-init.sh
+++ b/docs/chapters/baseplatform/snippets/repo-init.sh
@@ -1,0 +1,5 @@
+mkdir pelux
+cd pelux
+repo init -u https://github.com/Pelagicore/pelux-manifests.git \
+     -m <manifest> -b <branch>
+repo sync

--- a/docs/chapters/baseplatform/snippets/repo-source.sh
+++ b/docs/chapters/baseplatform/snippets/repo-source.sh
@@ -1,0 +1,2 @@
+TEMPLATECONF=`pwd`/sources/meta-pelux-bsp-intel/conf/ \
+            source sources/poky/oe-init-build-env build

--- a/docs/chapters/baseplatform/using-the-repo-tool.rst
+++ b/docs/chapters/baseplatform/using-the-repo-tool.rst
@@ -1,0 +1,23 @@
+.. _using-the-repo-tool:
+
+Using the repo tool
+===================
+
+The ``repo`` tool is used to obtain the sources of a PELUX release. ``repo`` was originally developed by the Android [#android]_ project, and it is used to clone specific versions of git repositories into specific locations.
+
+Obtaining the repo tool
+-----------------------
+
+If you already have a directory in your ``$PATH`` for placing user-specific runnables, you should use that location, if not perform the following steps:
+
+.. literalinclude:: snippets/export.sh
+    :language: bash
+
+Note that you need to replace ``~/.bashrc`` with the correct rc-file for your shell.
+
+.. literalinclude:: snippets/curl.sh
+    :language: bash
+
+The ``repo`` command should now be available from your shell.
+
+.. [#android] http://source.android.com

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,9 +5,10 @@ Revision: |release|
 
 .. toctree::
     :caption: Table of contents:
-    :maxdepth: 2
+    :maxdepth: 3
     :glob:
 
     chapters/intro/*
     chapters/workflow/*
+    chapters/baseplatform/index.rst
 


### PR DESCRIPTION
This commit adds information for a platform developer on how to obtain
the repo tool, check out the source code with it and build their
first image.

It's not very nice built because I used `include` and this seems to make
it impossible to exchange parts of it in the main index file. But let's
start with something like that first.