### PR TITLE
Add SDK entry point

### DIFF
--- a/docs/chapters/sdk/index.rst
+++ b/docs/chapters/sdk/index.rst
@@ -1,0 +1,8 @@
+Software Development Kit
+************************
+
+PELUX provides a Software Development Kit (SDK), for quick and easy development of software components for a PELUX (or PELUX-based) system. The SDK is mainly targeted towards service implementers but can be used for developing applications and other kinds of software components as well. The SDK installer script can be downloaded from `PELUX website`_. Each SDK installer is for a specific target hardware platform.
+
+.. _`PELUX website`: http://pelux.io/downloads
+
+TBD: Information on how to use the SDK.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,4 +11,5 @@ Revision: |release|
     chapters/intro/*
     chapters/workflow/*
     chapters/baseplatform/index.rst
+    chapters/sdk/index.rst
 


### PR DESCRIPTION
Add a section for service developers to obtain the SDK from. For now we
just introduce SDK and where to get it. Also the link to downloads is
bogus until we the website setup and our first release done.

Is this what we are looking for?