### PR TITLE
CMakeLists.txt: Add version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,5 +6,13 @@
 
 cmake_minimum_required(VERSION 3.0.2)
 
+set(MAJOR_VERSION 0)
+set(MINOR_VERSION 1)
+set(PATCH_LEVEL 0)
+
+# The VERSION variable is used in the Sphinx config when creating a
+# version string.
+set(VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_LEVEL})
+
 add_subdirectory(docs)
 


### PR DESCRIPTION
This version number is used by the Sphinx config to
build a version string together with the git revision.

Signed-off-by: Joakim Gross <joakim.gross@pelagicore.com>