### PR TITLE
Change to "Read the Docs" theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Maintainer: Joakim Gross <joakim.gross@pelagicore.com>
 * sphinxcontrib-blockdiag
 * sphinxcontrib-actdiag
 * sphinxcontrib-manpage
+* sphinx\_rtd\_theme
 * texlive-latex-base (when building PDF)
 * texlive-latex-extra (when building PDF)
 * texlive-latex-recommended (when building PDF)
@@ -23,7 +24,7 @@ Maintainer: Joakim Gross <joakim.gross@pelagicore.com>
 sudo apt-get install python-pip
 pip install sphinxcontrib-seqdiag sphinxcontrib-blockdiag \
               sphinxcontrib-actdiag sphinxcontrib-actdiag \
-              sphinxcontrib-manpage
+              sphinxcontrib-manpage sphinx_rtd_theme
 ```
 
 

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -100,7 +100,11 @@ actdiag_html_image_format = "SVG"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+# The Read the Docs theme is available from
+# - https://github.com/snide/sphinx_rtd_theme
+# - https://pypi.python.org/pypi/sphinx_rtd_theme
+# - python-sphinx-rtd-theme package (on Debian)
+html_theme = "sphinx_rtd_theme"
 
 # html_logo = None
 # html_favicon = None


### PR DESCRIPTION
The theme we use now doesn't have a sidebar with an easy accessible
and expandable tree for the documentation, therefor it is difficult
to read.

The "Read the Docs" theme, which is also used by the Linux Kernel
documentation is much nicer and will make it possible for us to
stop using the includes and start using the index properly.

There is still a lot to do, for example to rewrite the homepage
and to remove all the includes but this step makes it already
much easier to browse and read.