### PR TITLE
Introduce the project() cmake command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,6 @@
 
 cmake_minimum_required(VERSION 3.0.2)
 
-set(MAJOR_VERSION 0)
-set(MINOR_VERSION 1)
-set(PATCH_LEVEL 0)
-
-# The VERSION variable is used in the Sphinx config when creating a
-# version string.
-set(VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_LEVEL})
+project(software-factory VERSION 0.1.0)
 
 add_subdirectory(docs)
-

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -67,8 +67,8 @@ project = u'@PROJECT_NAME@'
 copyright = u'Pelagicore AB'
 author = u'Pelagicore AB'
 
-version = u'@VERSION@'
-release = u"@VERSION@-@REVISION@ @DATE@"
+version = u'@PROJECT_VERSION@'
+release = u"@PROJECT_VERSION@-@REVISION@ @DATE@"
 
 language = None
 


### PR DESCRIPTION
This fixes the generic "project" header for the generated documentation
as well as reuses the standard cmake versioning macros.

See https://cmake.org/cmake/help/v3.0/command/project.html for more info.