### PR TITLE
conf.py.in: remove unused cruft

### DIFF
--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -65,10 +65,6 @@ rst_epilog = ""
 for key in substs.keys():
     rst_epilog += ".. |%s| replace:: %s\n" % (key, substs[key])
 
-def setup(app):
-    for key in substs:
-        app.add_config_value(key, substs[key], 'env')
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 source_suffix = '.rst'


### PR DESCRIPTION
Some code points were added before to try out the ifconfig directive in
sphinx, but since it is not used anymore, we don't need the config
values for it either.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>