### PR TITLE
Jenkinsfile: add submodules

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,10 @@ pipeline {
                 
                 // Checkout the git repository and refspec pointed to by jenkins
                 checkout scm
+
+                // Update the submodule
+                sh "git submodule init"
+                sh "git submodule update"
             }
         }
         

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
             steps {
                 // Delete old files
                 sh 'rm -rf .[^.] .??* *'
-                
+
                 // Checkout the git repository and refspec pointed to by jenkins
                 checkout scm
 
@@ -25,7 +25,7 @@ pipeline {
                 sh "git submodule update"
             }
         }
-        
+
         // Configure the software with cmake
         stage('Configure') {
             steps {
@@ -48,7 +48,7 @@ pipeline {
                 // Store the artifacts of the entire build
                 archive "**/*"
             }
-        }        
+        }
     }
-    
+
 }


### PR DESCRIPTION
Automated CI builds fail because this SWF now depends on the Blueprint which is included as a submodule.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>