### PR TITLE
sdk: remove includes that are now in template

### DIFF
--- a/docs/chapters/sdk/index.rst
+++ b/docs/chapters/sdk/index.rst
@@ -11,6 +11,4 @@ specific target hardware platform.
 
 .. include:: installing-the-sdk.rst
 .. include:: ../../swf-blueprint/docs/articles/sdk/using-the-sdk-to-crosscompile.rst
-.. include:: template-service.rst
-.. include:: ../../swf-blueprint/docs/articles/sdk/directory-structure.rst
 .. include:: ../../swf-blueprint/docs/articles/sdk/run-binary-on-target.rst


### PR DESCRIPTION
Some articles that were moved as part of the template-chapter were still
included in the sdk chapter.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>