### PR TITLE
Make ditc() update working with python3

### DIFF
--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -56,9 +56,11 @@ substs.update(project_substitutions)
 # Duplicate all entries with different formatting options
 # This ensures that even formatted versions of the words in substs variable
 # get substituted
+s = dict()
 for key in substs.keys():
-    substs[key + "-code"] = "``" + substs[key] + "``"
-    substs[key + "-emph"] = "`" + substs[key] + "`"
+    s[key + "-code"] = "``" + substs[key] + "``"
+    s[key + "-emph"] = "`" + substs[key] + "`"
+substs.update(s)
 
 # Substitutes all keys in substs variable with their values in that map
 rst_epilog = ""


### PR DESCRIPTION
Iterating over a dict at the same time as adding items to it isn't
allowed in python3. This patch adds a new dict for the loop and
updates the old dict after the loop.

Signed-off-by: Henrik Hugo <hhugo@luxoft.com>