### PR TITLE
Restructure the index files and add CI articles

### DIFF
--- a/docs/chapters/baseplatform/booting-on-target-hardware.rst
+++ b/docs/chapters/baseplatform/booting-on-target-hardware.rst
@@ -1,11 +1,3 @@
-
-.. include:: ../../swf-blueprint/docs/articles/baseplatform/writing-image.rst
-
-Image names for PELUX targets
------------------------------
-* NUC/Minnowboard: ``core-image-pelux-intel-corei7-64.wic``
-* Raspberry Pi 3: ``core-image-pelux-raspberrypi3.rpi-sdimg``
-
 Booting on target hardware
 ==========================
 
@@ -20,4 +12,3 @@ Raspberry Pi 3
 Insert the SD-card into the Raspberry Pi and boot it up.
 
 .. note:: Login as user ``root``.
-

--- a/docs/chapters/baseplatform/building-PELUX-sources.rst
+++ b/docs/chapters/baseplatform/building-PELUX-sources.rst
@@ -1,5 +1,8 @@
-Obtaining a PELUX release
-=========================
+Building PELUX sources
+======================
+
+This chapter details how to download and configure the sources of a PELUX build, so
+that an image can be built.
 
 The following manifests can be used for a build:
 

--- a/docs/chapters/baseplatform/deploying-the-image.rst
+++ b/docs/chapters/baseplatform/deploying-the-image.rst
@@ -1,0 +1,7 @@
+
+.. include:: ../../swf-blueprint/docs/articles/baseplatform/writing-image.rst
+
+Image names for PELUX targets
+-----------------------------
+* NUC/Minnowboard: ``core-image-pelux-intel-corei7-64.wic``
+* Raspberry Pi 3: ``core-image-pelux-raspberrypi3.rpi-sdimg``

--- a/docs/chapters/baseplatform/index.rst
+++ b/docs/chapters/baseplatform/index.rst
@@ -6,10 +6,14 @@ PELUX as a platform is compiled from a lot of different projects with help of Yo
 .. _Yocto: http://yoctoproject.org/
 .. _`their documentation`: https://www.yoctoproject.org/documentation
 
-.. include:: ../../swf-blueprint/docs/articles/baseplatform/prerequisites.rst
-.. include:: ../../swf-blueprint/docs/articles/baseplatform/using-the-repo-tool.rst
-.. include:: obtaining-a-PELUX-release.rst
-.. include:: deploying-and-booting-the-image.rst
-.. include:: ../../swf-blueprint/docs/articles/baseplatform/creating-sdk.rst
-.. include:: creating-a-manifest.rst
-.. include:: ../../swf-blueprint/docs/articles/baseplatform/creating-a-new-layer.rst
+.. toctree::
+   
+   ../../swf-blueprint/docs/articles/baseplatform/prerequisites
+   ../../swf-blueprint/docs/articles/baseplatform/using-the-repo-tool
+   building-PELUX-sources
+   deploying-the-image
+   booting-on-target-hardware
+   ../../swf-blueprint/docs/articles/baseplatform/creating-sdk
+   creating-a-manifest
+   ../../swf-blueprint/docs/articles/baseplatform/creating-a-new-layer
+   ../../swf-blueprint/docs/articles/baseplatform/variant-concept-in-yocto

--- a/docs/chapters/ci-and-cd/index.rst
+++ b/docs/chapters/ci-and-cd/index.rst
@@ -1,5 +1,10 @@
 Continuous integration and deployment
 *************************************
 
-.. include:: setting-up-automated-testing-yocto.rst
+.. toctree::
+   
+    ../../swf-blueprint/docs/articles/infrastructure/ci-cd/host
+    ../../swf-blueprint/docs/articles/infrastructure/ci-cd/jenkins
+    ../../swf-blueprint/docs/articles/infrastructure/ci-cd/build-slaves
+    setting-up-automated-testing-yocto
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,17 +1,21 @@
-
 Welcome to the Software Factory documentation
 *********************************************
 Revision: |release|
 
-.. toctree::
-    :caption: Table of contents:
-    :maxdepth: 3
-    :glob:
+-------------------
 
-    chapters/intro/index.rst
-    chapters/workflow/index.rst
-    chapters/baseplatform/index.rst
-    chapters/ci-and-cd/index.rst
-    chapters/sdk/index.rst
-    swf-blueprint/docs/articles/templates/index.rst
-    swf-blueprint/docs/articles/licensing/index.rst
+The Software Factory documentation is the central space where we collect all useful information on how to work within the project.
+
+-------------------
+
+.. toctree::
+    :caption: Table of contents
+    :maxdepth: 3
+
+    chapters/workflow/index
+    chapters/baseplatform/index
+    chapters/ci-and-cd/index
+    chapters/sdk/index
+    swf-blueprint/docs/articles/templates/index
+    swf-blueprint/docs/articles/licensing/index
+    swf-blueprint/docs/articles/intro/index


### PR DESCRIPTION
After the resturturing work in the blueprint it is now easier to
use it in a project. This patch changes some of the index files
so they would not use include anymore but toctrees instead.

It also adds some articles from the blueprint like those about the
CI and the blueprint itself.