### PR TITLE
Setup tagging system

### DIFF
--- a/docs/categories/howto.rst
+++ b/docs/categories/howto.rst
@@ -1,0 +1,4 @@
+How-to articles
+***************
+
+.. taglist:: howto

--- a/docs/categories/process.rst
+++ b/docs/categories/process.rst
@@ -1,0 +1,4 @@
+Processes
+*********
+
+.. taglist:: process

--- a/docs/chapters/workflow/index.rst
+++ b/docs/chapters/workflow/index.rst
@@ -1,3 +1,9 @@
+Git workflow
+************
 
-.. include:: ../../swf-blueprint/docs/articles/workflow/git-workflow.rst
-.. include:: github-tips-and-tricks.rst
+.. toctree::
+    :caption: Table of contents
+    :maxdepth: 3
+
+    ../../swf-blueprint/docs/articles/workflow/git-workflow.rst
+    github-tips-and-tricks.rst

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -42,7 +42,8 @@ extensions = [
     'sphinxcontrib.manpage',
     'sphinxcontrib.blockdiag',
     'sphinxcontrib.seqdiag',
-    'sphinxcontrib.actdiag'
+    'sphinxcontrib.actdiag',
+    'sphinxexts.taglist'
 ]
 
 # Substitutions for common names. Key is replaced value in the text of all .rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,3 +19,10 @@ The Software Factory documentation is the central space where we collect all use
     swf-blueprint/docs/articles/templates/index
     swf-blueprint/docs/articles/licensing/index
     swf-blueprint/docs/articles/intro/index
+
+.. toctree::
+    :caption: Categories
+    :maxdepth: 1
+
+    categories/howto.rst
+    categories/process.rst


### PR DESCRIPTION
Update the blueprint submodule, add taglist extension to the configuration
and setup category pages.

Switch from include to using tocree in git workflow. Otherwise, there would be two documents titled "Git workflow" tagged with "howto".

Signed-off-by: Henrik Hugo <hhugo@luxoft.com>