### PR TITLE
CMakeLists.txt: better project name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@
 
 cmake_minimum_required(VERSION 3.0.2)
 
-project(software-factory VERSION 0.1.0)
+project("PELUX Baseline Software Factory"
+        VERSION 0.1.0
+        LANGUAGES NONE
+)
 
 add_subdirectory(docs)


### PR DESCRIPTION
The project name variable is used to set title etc in the Sphinx theme,
so choosing something more descriptive is a good idea.

Also removed the check for C/C++ compiler.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>