### PR TITLE
Add cmake dependency to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Maintainer: Joakim Gross <joakim.gross@pelagicore.com>
 
 
 ## Dependencies
+* cmake
 * Sphinx
 * sphinxcontrib-seqdiag
 * sphinxcontrib-blockdiag
@@ -21,7 +22,7 @@ Maintainer: Joakim Gross <joakim.gross@pelagicore.com>
 ###  Install build dependencies on Debian
 
 ```
-sudo apt-get install python-pip
+sudo apt-get install cmake python-pip
 sudo pip install sphinxcontrib-seqdiag sphinxcontrib-blockdiag \
               sphinxcontrib-actdiag sphinxcontrib-manpage sphinx_rtd_theme
 ```


### PR DESCRIPTION
CMake has been missing as a dependency which often leads to the fact
that when you set up a new server you forget to install it and then
the project can't be build.

This patch adds it to the README in the list and the apt command.

Fixes #48