### PR TITLE
Add Open source office chapter with some basic text

### DIFF
--- a/docs/chapters/oso/checklist-for-peer-reviewing-repository-requirements.rst
+++ b/docs/chapters/oso/checklist-for-peer-reviewing-repository-requirements.rst
@@ -1,0 +1,17 @@
+Checklist for peer reviewing repository requirements
+====================================================
+
+#. Make sure that the following files are present in the root of the source code
+   repository:
+
+   * LICENSE: Stating the license of the source code.
+   * README.md: Containing information on where to find the documentation of the
+     product. There should also be a notice of where the code is maintained and
+     a reference to the LICENSE file for complete license information.
+   * CONTRIBUTING.md: Containing information on how to contribute. This includes
+     where to report bugs, where to ask questions and where to send code patches.
+
+#. Go through file headers of all the source code produced by this project and
+   make sure that in each file there is a copyright notice, a reference to the
+   LICENSE file and a SPDX tag.
+

--- a/docs/chapters/oso/index.rst
+++ b/docs/chapters/oso/index.rst
@@ -7,3 +7,7 @@ When making software open source there are some steps that need to be completed.
 The purpose of these steps is to ensure that the code has a sound license, the
 source code repository is understandable and that there are clear descriptions
 on how to contribute.
+
+.. toctree::
+    checklist-for-peer-reviewing-repository-requirements.rst
+

--- a/docs/chapters/oso/index.rst
+++ b/docs/chapters/oso/index.rst
@@ -1,0 +1,9 @@
+Open Source Office
+******************
+
+Open source office handles tasks regarding license compliance of software and how to engage community etc.
+
+When making software open source there are some steps that need to be completed.
+The purpose of these steps is to ensure that the code has a sound license, the
+source code repository is understandable and that there are clear descriptions
+on how to contribute.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ The Software Factory documentation is the central space where we collect all use
     chapters/ci-and-cd/index
     chapters/sdk/index
     chapters/sde/index
+    chapters/oso/index
     swf-blueprint/docs/articles/templates/index
     swf-blueprint/docs/articles/licensing/index
 


### PR DESCRIPTION
The point of this PR is to create a first brief of the OSO chapter.
It also adds a peer-review-checklist

Questions:
* how should/does this relate to the "licensing" part in SWF-blueprint?
* should it be called something else?
* is this enough as a first thing ?
* should something be moved to the SWF-blueprint?
