### PR TITLE
building-PELUX: add note about -dev images

### DIFF
--- a/docs/chapters/baseplatform/building-PELUX-sources.rst
+++ b/docs/chapters/baseplatform/building-PELUX-sources.rst
@@ -10,6 +10,15 @@ building, and decide what image to build. Currently there are two versions:
 being a version that includes `Qt Automotive Suite`_ components that enable the
 NeptuneUI demo application.
 
+A note on development images
+----------------------------
+Both PELUX images are available as `-dev` versions, which, for example, sets an
+empty root password and allows empty password login via ssh. This is usually
+useful during development. The base image for PELUX sets a default root password
+to "root", unless the `-dev` image is used.
+
+The `-dev` images also install various useful tools for development and
+debugging, such as gdb, strace and so on.
 
 Building locally
 ----------------


### PR DESCRIPTION
The -dev images sets empty root pw etc, and since the non-dev randomizes
the root pw, this should be mentioned.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>