### PR TITLE
Treat sphinx warnings as errors

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -49,7 +49,7 @@ configure_file(
 
 add_custom_target(sphinx-html
     ${SPHINX_EXECUTABLE}
-        -q -b html
+        -q -W -b html
         -c "${BINARY_BUILD_DIR}"
         -d "${SPHINX_CACHE_DIR}"
         "${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
We want to treat sphinx warnings as errors. This will fail jenkins builds if a PR contains bad formatting and discourage merging.

Signed-off-by: Henrik Hugo <hhugo@luxoft.com>