### PR TITLE
Add missing vagrant-scp plugin

### DIFF
--- a/docs/chapters/baseplatform/building-PELUX-sources.rst
+++ b/docs/chapters/baseplatform/building-PELUX-sources.rst
@@ -140,6 +140,7 @@ Procedure:
 
 .. code-block:: bash
 
+    vagrant plugin install vagrant-scp
     vagrant scp :${yoctoDir}/build/tmp/deploy/images ../images
 
 


### PR DESCRIPTION
vagrant-scp plugin is missing in the guide.

Signed-off-by: Chuan Jin <chuan.jin.813@gmail.com>