### PR TITLE
building/booting: add links to QEMU articles

### DIFF
--- a/docs/aspell.en.pws
+++ b/docs/aspell.en.pws
@@ -129,3 +129,4 @@ API
 functionalities
 tagname
 SHA
+nogfx

--- a/docs/chapters/baseplatform/booting-on-target-hardware.rst
+++ b/docs/chapters/baseplatform/booting-on-target-hardware.rst
@@ -14,3 +14,7 @@ Raspberry Pi 3
 Insert the SD-card into the Raspberry Pi and boot it up. Make sure to use the
 HDMI output.
 
+QEMU
+----
+
+Booting up a QEMU image is described in :ref:`booting-a-qemu-image`.

--- a/docs/chapters/baseplatform/building-PELUX-sources.rst
+++ b/docs/chapters/baseplatform/building-PELUX-sources.rst
@@ -48,7 +48,8 @@ configuration samples from.
 .. note:: The example below get the template configuration for the Intel BSP
           without Qt Automotive Suite (QtAS). Use ``intel-qtauto`` as the last
           part of the path to get QtAS support. The same pattern is used for the
-          Raspberry Pi BSP (``rpi`` and ``rpi-qtauto``).
+          Raspberry Pi BSP (``rpi`` and ``rpi-qtauto``). There is also
+          experimental support for ``qemu-x86-64-nogfx``.
 
 .. code-block:: bash
 


### PR DESCRIPTION
We have experimental support for qemu target, so we describe
that in the docs properly. Article for how to boot was already in the
blueprint.

Don't merge until [blueprint/#81](https://github.com/Pelagicore/software-factory-blueprint/pull/81) is merged. The CI will fail here until we update the blueprint once it is merged.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>