### PR TITLE
Jenkinsfile: build in Docker instead of natively

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:17.10
+
+RUN apt-get update && apt-get install -y \
+	cmake \
+	git \
+	locales \
+	python3-pip \
+	enchant
+
+RUN pip3 install \
+	sphinx_rtd_theme \
+	sphinxcontrib-actdiag \
+	sphinxcontrib-blockdiag \
+	sphinxcontrib-manpage \
+	sphinxcontrib-seqdiag \
+	sphinxcontrib-spelling
+
+RUN rm -rf /var/lib/apt/lists/*
+
+# Add support for UTF-8 when spellchecking.
+
+RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG en_US.utf8

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@
 
 pipeline {
     agent {
-        node { label 'Sphinx' }
+        dockerfile true
     }
 
     stages {


### PR DESCRIPTION
This eliminates the need to track dependencies on the host systems on
the servers, and the Dockerfile serves as a makeshift documentation for
what the dependencies are.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>