### PR TITLE
Use sphinxcontrib-spelling instead of aspell

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
         stage('Configure') {
             steps {
                 script {
-                    String buildParams = "-DENABLE_PDF=OFF -DPERFORM_SPELL_CHECK=ON "
+                    String buildParams = "-DENABLE_PDF=OFF"
                     sh "rm -fr build"
                     sh "cmake -H. -Bbuild ${buildParams}"
                 }

--- a/README.md
+++ b/README.md
@@ -57,23 +57,8 @@ language specific dictionaries and project specific dictionaries
 case of any typos.
 
 The project, which uses this blueprint, should have its own custom dictionary,
-similar to the one in blueprint (spelling_wordlist.txt). Currently, the
-sphinxcontrib-spelling module does not support multiple wordlists, so one should
-concatenate all wordlists to one specific list. In CMake, that can be done as
-follows:
-
-    add_custom_target(spelling
-        find "${CMAKE_CURRENT_SOURCE_DIR}" -iname "${WORDLIST_FILE}" -type f | xargs cat > ${BINARY_BUILD_DIR}/${WORDLIST_FILE}
-        COMMAND ${SPHINX_EXECUTABLE}
-            -W -b spelling
-            -c "${BINARY_BUILD_DIR}"
-            -d "${SPHINX_CACHE_DIR}"
-            "${CMAKE_CURRENT_SOURCE_DIR}"
-            "${CMAKE_BINARY_DIR}/spelling"
-        COMMENT "Spell-checking documentation with Sphinx"
-
-`WORDLIST_FILE` is added to `conf.py` as the source for spelling, which the
-sphinx spelling module then picks up.
+similar to the one in blueprint (spelling_wordlist.txt). One can supply
+multiple word lists to the spell-checker plugin, see `conf.py.in`
 
 The spell checker is added as a custom target, so to run it manually, simply
 type (after running cmake):

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -42,15 +42,13 @@ set(SPHINX_HTML_DIR "${CMAKE_CURRENT_BINARY_DIR}/html")
 # PDF output directory
 set(SPHINX_PDF_DIR "${CMAKE_CURRENT_BINARY_DIR}/pdflatex")
 
-set(WORDLIST_FILE "spelling_wordlist.txt")
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/conf.py.in"
     "${BINARY_BUILD_DIR}/conf.py"
     @ONLY)
 
 add_custom_target(spelling
-    find "${CMAKE_CURRENT_SOURCE_DIR}" -iname "${WORDLIST_FILE}" -type f | xargs cat > ${BINARY_BUILD_DIR}/${WORDLIST_FILE}
-    COMMAND ${SPHINX_EXECUTABLE}
+    ${SPHINX_EXECUTABLE}
         -W -b spelling
         -c "${BINARY_BUILD_DIR}"
         -d "${SPHINX_CACHE_DIR}"

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -42,20 +42,22 @@ set(SPHINX_HTML_DIR "${CMAKE_CURRENT_BINARY_DIR}/html")
 # PDF output directory
 set(SPHINX_PDF_DIR "${CMAKE_CURRENT_BINARY_DIR}/pdflatex")
 
+set(WORDLIST_FILE "spelling_wordlist.txt")
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/conf.py.in"
     "${BINARY_BUILD_DIR}/conf.py"
     @ONLY)
 
-add_custom_target(spell-check
-    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/check_spelling.sh" "-q" -w "${CMAKE_CURRENT_SOURCE_DIR}"
-    COMMENT "Performing spell check"
+add_custom_target(spelling
+    find "${CMAKE_CURRENT_SOURCE_DIR}" -iname "${WORDLIST_FILE}" -type f | xargs cat > ${BINARY_BUILD_DIR}/${WORDLIST_FILE}
+    COMMAND ${SPHINX_EXECUTABLE}
+        -W -b spelling
+        -c "${BINARY_BUILD_DIR}"
+        -d "${SPHINX_CACHE_DIR}"
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+        "${CMAKE_BINARY_DIR}/spelling"
+    COMMENT "Spell-checking documentation with Sphinx"
 )
-
-option(PERFORM_SPELL_CHECK "Perform the spell check" ON)
-if(PERFORM_SPELL_CHECK)
-    add_dependencies(doc spell-check)
-endif()
 
 add_custom_target(sphinx-html
     ${SPHINX_EXECUTABLE}
@@ -77,7 +79,7 @@ add_custom_target(sphinx-latexpdf
     COMMAND make -C "${SPHINX_PDF_DIR}" all-pdf > /dev/null
     COMMENT "Building Latex/PDF documentation with Sphinx")
 
-add_dependencies(doc sphinx-html)
+add_dependencies(doc spelling sphinx-html)
 
 option(ENABLE_PDF "Enable building documentation in PDF format" OFF)
 if(ENABLE_PDF)

--- a/docs/check_spelling.sh
+++ b/docs/check_spelling.sh
@@ -1,1 +1,0 @@
-swf-blueprint/docs/check_spelling.sh

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -25,6 +25,7 @@ THISDIR='@CMAKE_CURRENT_SOURCE_DIR@'
 # Include the blueprint path, and include the substitutions from the blueprint
 sys.path.append(os.path.abspath(os.path.join(THISDIR, 'swf-blueprint/docs/python_modules')))
 from substitutions import subst as blueprint
+from enchantfilters import SWFFilters
 
 # -- General configuration ------------------------------------------------
 
@@ -43,6 +44,7 @@ extensions = [
     'sphinxcontrib.blockdiag',
     'sphinxcontrib.seqdiag',
     'sphinxcontrib.actdiag',
+    'sphinxcontrib.spelling',
     'sphinxexts.taglist'
 ]
 
@@ -82,6 +84,15 @@ version = u'@PROJECT_VERSION@-alpha'
 release = u"@PROJECT_VERSION@-alpha-@REVISION@ @DATE@"
 
 language = None
+
+# Spelling options
+spelling_lang='en_US'
+spelling_word_list_filename='@BINARY_BUILD_DIR@/@WORDLIST_FILE@'
+selling_show_suggestions=True
+
+# The spell-checker does not recognize the git hash in the revision string
+# on the front page automatically, so we wrote a custom filter for that.
+spelling_filters=[SWFFilters.VersionStringFilter]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -87,7 +87,7 @@ language = None
 
 # Spelling options
 spelling_lang='en_US'
-spelling_word_list_filename='@BINARY_BUILD_DIR@/@WORDLIST_FILE@'
+spelling_word_list_filename=['spelling_wordlist.txt','swf-blueprint/docs/spelling_wordlist.txt']
 selling_show_suggestions=True
 
 # The spell-checker does not recognize the git hash in the revision string

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,4 +1,3 @@
-personal_ws-1.1 en 119 
 runtime
 API
 sde
@@ -132,3 +131,6 @@ SHA
 nogfx
 UCM
 middleware
+USB
+fallback
+tarball


### PR DESCRIPTION
There are some hickups when it comes to using several word list files,
but the maintainer of the plugin is open to patches!

Depends on [SWF-blueprint/#88](https://github.com/Pelagicore/software-factory-blueprint/pull/88)

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>