### PR TITLE
Installing the SDK: Remove warning about SDK version

### DIFF
--- a/docs/chapters/sdk/installing-the-sdk.rst
+++ b/docs/chapters/sdk/installing-the-sdk.rst
@@ -8,9 +8,5 @@ while.
 
 Or you can of course build it yourself as described in :ref:`building-the-sdk`.
 
-.. note:: Note that the version number at the end of the SDK download file is
-          not the version of the SDK but in fact the version number of poky,
-          which is the upstream Yocto distribution PELUX is using.
-
 .. _`PELUX website`: http://pelux.io/downloads
 


### PR DESCRIPTION
Since https://github.com/Pelagicore/meta-pelux/pull/93/commits/2dc7f1c8a82f387f05842f3ab849f1b70787c94c
This is not relevant anymore.

Signed-off-by: Florent Revest <revestflo@gmail.com>