### PR TITLE
Jenkinsfile-deploy: better node selector

### DIFF
--- a/scripts/Jenkinsfile-deploy
+++ b/scripts/Jenkinsfile-deploy
@@ -61,8 +61,7 @@ def shouldWeRun = { String shaFile ->
     return params.FORCE_DEPLOY || shouldRun != 0
 }
 
-// We run this on any node that has Sphinx and web server access
-node('WWW') {
+node('WWW' && !master) {
 
     // For scope reasons we define it here
     String[] buildList = []


### PR DESCRIPTION
With the old selector we sometimes end up on master where there is no sphinx support etc.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>