### PR TITLE
Hawkbit dependencies clarification

### DIFF
--- a/docs/chapters/architecture/SOTA-system.rst
+++ b/docs/chapters/architecture/SOTA-system.rst
@@ -490,7 +490,7 @@ on an IP network:
 
 - A development machine running a standard Linux distribution. We will assume
   that this machine has the *192.168.3.11* IP address. This machine must have
-  Java 1.8 and Maven installed.
+  Java 1.8, Maven and rabbitmq-server installed.
 - A raspberrypi3 running PELUX. 
 
 Compiling SWUpdate artifacts

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -150,3 +150,4 @@ offboard
 Surricata
 plugin
 bootloaders
+rabbitmq


### PR DESCRIPTION
This makes a dependency rom Hawkbit to RabbitMQ more obvious.
More importantly, this also documents the exact steps of setting up a persistent database for Hawkbit. The official documentation was incomplete, lacking important steps such as an SQL request that has to be typed in manually.