### PR TITLE
Software Development Kit: Point to the QtCreator configuration page

### DIFF
--- a/docs/chapters/sdk/index.rst
+++ b/docs/chapters/sdk/index.rst
@@ -14,4 +14,5 @@ specific target hardware platform.
     ../../swf-blueprint/docs/articles/sdk/installing-the-sdk.rst
     ../../swf-blueprint/docs/articles/sdk/using-the-sdk-to-crosscompile.rst
     ../../swf-blueprint/docs/articles/sdk/run-binary-on-target.rst
+    ../../swf-blueprint/docs/articles/sdk/configure-qtcreator.rst
     ../../swf-blueprint/docs/articles/sdk/read-system-logs.rst


### PR DESCRIPTION
This page is an useful addition to the SDK chapter.

Signed-off-by: Florent Revest <revestflo@gmail.com>