### PR TITLE
Spellcheck: remove modals

### DIFF
--- a/docs/chapters/architecture/SOTA-system.rst
+++ b/docs/chapters/architecture/SOTA-system.rst
@@ -389,7 +389,7 @@ The developers of SWUpdate also provide a meta-swupdate-boards layer with
 example recipes on how to integrate SWUpdate to a couple of platforms. Most of
 the code in this layer is irrelevant to us since it refers to a demo
 "core-image-full-cmdline" image and to platforms such as the wandboard or
-beaglebone which aren't supported by PELUX.
+beaglebone which are not supported by PELUX.
 
 meta-swupdate has been integrated to the default PELUX manifests, to avoid code
 duplication. However, it has been decided that the meta-swupdate-boards
@@ -521,7 +521,7 @@ We will fetch Hawkbit from its GitHub repository.
     $ git clone https://github.com/eclipse/hawkbit
     $ cd hawkbit
 
-Recent versions of Hawkbit aren't yet supported by SWUpdate so we need to
+Recent versions of Hawkbit are not yet supported by SWUpdate so we need to
 manually select a slightly older version of Hawkbit.
 
 .. code-block:: bash
@@ -643,7 +643,7 @@ Going further
 Persistent storage
 """"""""""""""""""
 
-The above instructions don't use a database to store artifacts and metadata.
+The above instructions do not use a database to store artifacts and metadata.
 This means that every time Hawkbit will be restarted, its rollout campaigns
 will be lost. This is handy for a development environment but unsustainable for
 a real world scenario.

--- a/docs/chapters/baseplatform/building-PELUX-sources.rst
+++ b/docs/chapters/baseplatform/building-PELUX-sources.rst
@@ -124,7 +124,7 @@ Building with Vagrant
 
 When we build internally at Pelagicore in our CI system, we use Docker with
 Vagrant, however only in a GNU/Linux system. It should still work under Windows
-or OSX, but we haven't tried it.
+or OSX, but we have not tried it.
 
 Dependencies:
 ^^^^^^^^^^^^^

--- a/docs/chapters/baseplatform/replacing-packagegroups.rst
+++ b/docs/chapters/baseplatform/replacing-packagegroups.rst
@@ -33,7 +33,7 @@ then simply include the following line in the new image-recipe.
 
 If the new image want to omit all of the Qt Auto components in the above mentioned packagegroups
 and add some other component ``<other-component>``, then it can simply inherit from ``core-image-pelux`` 
-in it's image-recipe and append ``<other-component>`` to the image.
+in its image-recipe and append ``<other-component>`` to the image.
 
 .. code-block:: bash
 
@@ -63,4 +63,3 @@ are needed, then update the image-recipe as follows.
 
     TOOLCHAIN_HOST_TASK_remove = " nativesdk-packagegroup-b2qt-automotive-qt5-toolchain-host "
     TOOLCHAIN_TARGET_TASK_remove = " packagegroup-b2qt-automotive-qt5-toolchain-target "
-

--- a/docs/chapters/ci-and-cd/pelux-ci-cd-jobs.rst
+++ b/docs/chapters/ci-and-cd/pelux-ci-cd-jobs.rst
@@ -75,7 +75,7 @@ PELUX Software Factory Deploy
     served.
 
 Wipe Cache Weekly
-    Wipes out the Yocto cache once a week to make sure it doesn't grow out of
+    Wipes out the Yocto cache once a week to make sure it does not grow out of
     control.
 
 .. _multi-branch pipelines: https://wiki.jenkins.io/display/JENKINS/Pipeline+Multibranch+Plugin

--- a/docs/chapters/ci-and-cd/setting-up-automated-testing-yocto.rst
+++ b/docs/chapters/ci-and-cd/setting-up-automated-testing-yocto.rst
@@ -2,8 +2,8 @@ Setting up automated testing on a NUC using Yocto
 =================================================
 
 This article describes how automated deployment can be set up for test automation of images on a
-HW-target directly from bitbake on the build host. Relevant upstream documentation is available in the Yocto docs
-for automated runtime testing_.
+HW-target directly from bitbake on the build host. Relevant upstream documentation is available
+in the Yocto docs for automated runtime testing_.
 
 After following this how-to you should have:
 
@@ -13,25 +13,26 @@ After following this how-to you should have:
 
 How it works
 ------------
-In order to facilitate the deployment of images to the NUC a "testmaster" image is used. The NUC is setup to boot
-this testmaster image by default, and then bitbake can deploy the target rootfs and target kernel using scp and some
-scripting.
+In order to facilitate the deployment of images to the NUC a "testmaster" image is used. The NUC
+is setup to boot this testmaster image by default, and then bitbake can deploy the target rootfs
+and target kernel using scp and some scripting.
 
-The target rootfs is put on a separate partition, so the testmaster stays intact. Then the bootloader is
-told to boot a secondary entry called "test" once, and the target is rebooted which will cause it to boot using the
-rootfs and kernel that should be tested. The tests are then triggered using an ssh connection, and when all tests are
-done the target is rebooted once more so it ends up in testmaster image again.
+The target rootfs is put on a separate partition, so the testmaster stays intact. Then the
+bootloader is told to boot a secondary entry called "test" once, and the target is rebooted which
+will cause it to boot using the rootfs and kernel that should be tested. The tests are then
+triggered using an ssh connection, and when all tests are done the target is rebooted once more so
+it ends up in testmaster image again.
 
-There are hooks for enabling bitbake to power-cycle the NUC, which is required if the testing should be able
-to recover from e.g. images that doesn't boot. Without those hooks it depends on that a reboot can be initiated over an
-ssh connection. This how-to will not describe these hooks though.
+There are hooks for enabling bitbake to power-cycle the NUC, which is required if the testing should
+be able to recover from e.g. images that do not boot. Without those hooks it depends on that a
+reboot can be initiated over an ssh connection. This how-to will not describe these hooks though.
 
 
 Preparing the NUC
 -----------------
-There is an image called `core-image-testmaster` which is used as a basis for the setup. Following are a number of
-manual steps that need to be performed when deploying this image. The `repo` tool is used in the examples, for
-more information see :ref:`using-the-repo-tool`
+There is an image called `core-image-testmaster` which is used as a basis for the setup. Following
+are a number of manual steps that need to be performed when deploying this image. The `repo` tool
+is used in the examples, for more information see :ref:`using-the-repo-tool`
 
 Start by building the image:
 
@@ -55,11 +56,12 @@ Partition # File system Label      Comment
 4           ext3        testrootfs Will be mounted by scripts, so need correct label
 =========== =========== ========== =======
 
-Instead of deploying directly to the USB-stick using mkefidisk.sh we run mkefidisk on a file-backed loop-device
-in order to leave more space at the end of the disk for partition #4. Mkefidisk would otherwise grow the partition #2
-as much as possible to fill the USB-stick.
+Instead of deploying directly to the USB-stick using mkefidisk.sh we run mkefidisk on a file-backed
+loop-device in order to leave more space at the end of the disk for partition #4. Mkefidisk would
+otherwise grow the partition #2 as much as possible to fill the USB-stick.
 
-Please note that the last argument to mkefidisk.sh is the name of the device on the target HW, e.g. /dev/sda or /dev/mmcblk2, etc.
+Please note that the last argument to mkefidisk.sh is the name of the device on the target HW, e.g.
+/dev/sda or /dev/mmcblk2, etc.
 
 .. code-block:: bash
 
@@ -136,15 +138,15 @@ Now we mount the EFI partition to add a bootloader entry called "test" which boo
     # Unmount
     sudo umount /mnt
 
-The USB-stick should now be ready and can be inserted into a NUC and booted, do that and check what IP-address it gets
-using e.g. "ip a".
+The USB-stick should now be ready and can be inserted into a NUC and booted, do that and check what
+IP-address it gets using e.g. "ip a".
 
 
 Building and testing an image
 -----------------------------
 
-There is some configuration that needs to be setup in local.conf in order to enable target testing, so add the
-following to conf/local.conf
+There is some configuration that needs to be setup in local.conf in order to enable target testing,
+so add the following to conf/local.conf
 
 .. code-block:: bash
 
@@ -154,8 +156,8 @@ following to conf/local.conf
     TEST_TARGET_IP = "<IP of NUC>"
     TEST_SERVER_IP = "<IP of machine used for building>"
 
-Sometimes we need to set TEST_SERVER_IP, although that shouldn't be necessary according to the docs.
-This might be related to multiple network interfaces confusing the auto-detection.
+Sometimes we need to set TEST_SERVER_IP, although that should not be necessary according to
+the docs. This might be related to multiple network interfaces confusing the auto-detection.
 
 You can now build and test basically any image using ``bitbake -c testimage <my image>``, e.g.:
 
@@ -181,7 +183,7 @@ trigger a command via SSH. Other functionalities include files copying or
 package management. This module is documented `in the Yocto documentation`_.
 
 Adding a new test can be done by creating a new `.py` file under the
-`lib/oeqa/runtime/cases` directory of any Yocto layer. For instance, let's
+`lib/oeqa/runtime/cases` directory of any Yocto layer. For instance, let us
 create a minimal test case checking the output and status of the `echo` command.
 Put the following code into
 `sources/meta-pelux/lib/oeqa/runtime/cases/hello.py`
@@ -198,7 +200,7 @@ Put the following code into
             self.assertTrue(status == 0,"'echo hello' did not return a 0 status")
             self.assertTrue(output == "hello", "'echo hello' did not show hello")
 
-Bitbake can now find this test but it won't be executed by default. If you want
+Bitbake can now find this test but it will not be executed by default. If you want
 your test to be ran, you need to set the `TEST_SUITES` variable in your
 `local.conf`. For instance, add the following line:
 

--- a/docs/chapters/workflow/release/howto-release-pelux.rst
+++ b/docs/chapters/workflow/release/howto-release-pelux.rst
@@ -51,11 +51,11 @@ Prepare the manifest
 * Point to specific layer revisions in ``pelux.xml`` and push the manifest to
   the release branch.
 
-    * Don't point to tags here, since tags are moving targets. We create
+    * Do not point to tags here, since tags are moving targets. We create
       tags in our own layers for convenience, and to make maintenance
-      easier, but don't point to them here.
+      easier, but do not point to them here.
     * Make sure the commits pointed to are on the branches matching the
-      Yocto release we're targeting, and that they match what the tags point to.
+      Yocto release we are targeting, and that they match what the tags point to.
     * For the Qt layers, point to revisions for the Qt release targeted in
       this PELUX Baseline release.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ the dashboard of the car as well as the head-unit, which is usually placed in or
 above the center stack where one normally had just a radio back in the days.
 
 IVI systems are obviously put into cars by its car maker. However, most car
-makers don't develop the software for these systems in-house, but they contract
+makers do not develop the software for these systems in-house, but they contract
 a large software supplier. These software suppliers usually provide both
 hardware and software as a bundle.
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -157,3 +157,4 @@ Ubuntu
 blog
 licences
 archiver
+subdirectories


### PR DESCRIPTION
Change to use more formal language and avoid e.g. "don't", "shouldn't".

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>