### PR TITLE
Renaming Software Factory to Development Handbook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.0.2)
 
-project("PELUX Baseline Software Factory"
+project("PELUX Development Handbook"
         VERSION 3.0
         LANGUAGES NONE
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 
 project("PELUX Baseline Software Factory"
-        VERSION 2.0
+        VERSION 3.0
         LANGUAGES NONE
 )
 

--- a/docs/chapters/baseplatform/index.rst
+++ b/docs/chapters/baseplatform/index.rst
@@ -1,5 +1,5 @@
-Base Platform
-*************
+Reference Integration Platform
+******************************
 
 PELUX as a platform is compiled from a lot of different projects with help of Yocto_. In the long run a platform developer will need to get comfortable reading `their documentation`_ but it should be enough to read the chapters here to get started.
 

--- a/docs/chapters/ci-and-cd/index.rst
+++ b/docs/chapters/ci-and-cd/index.rst
@@ -1,4 +1,4 @@
-Continuous integration and deployment
+Continuous Integration and Deployment
 *************************************
 
 .. toctree::

--- a/docs/chapters/workflow/git/index.rst
+++ b/docs/chapters/workflow/git/index.rst
@@ -1,5 +1,5 @@
-Version control usage
-*********************
+Version Control System Usage
+****************************
 
 When working with software, version control is essential. This chapter shows how
 we try to work with version control, and git in particular, within PELUX.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,32 +1,34 @@
-Welcome to the PELUX Baseline Software Factory
-**********************************************
+Welcome to the PELUX Development Handbook
+*****************************************
 Revision: |release|
 
 -------------------
-
-What is the Software Factory?
------------------------------
-The Software Factory documentation contains processes, instructions and how-tos
-for how to work with PELUX, as well as instructions for how to create a
-standalone project based on PELUX.
 
 What is PELUX?
 --------------
 From pelux.io_:
 
-    *PELUX is a Linux based platform for your automotive infotainment project.
-    The PELUX software architecture is optimized to secure the shortest path
-    from silicon to pixel and thereby provide optimal performance to deliver a
-    stunning infotainment solution. It’s based on Yocto and offers an improved
-    developer experience.*
+    *PELUX is an agnostic reference integration platform that enables you to
+    build and develop automotive Linux-based systems without vendor lock-in.
+    As an open source solution accelerator, PELUX helps you prototype and create
+    production-ready, converged automotive systems, including advanced
+    driver-assistance systems (ADAS), telematics units and in-vehicle
+    infotainment systems.*
+
+What is the Development Handbook?
+---------------------------------
+The PELUX Development Handbook documentation contains processes, instructions
+and how-tos for how to work with PELUX, as well as instructions for how to
+create a standalone project based on PELUX.
 
 
 Why PELUX?
 ^^^^^^^^^^
-PELUX is a base platform for building automotive infotainment systems (IVI
-systems for short). IVI systems are usually responsible for everything shown in
-the dashboard of the car as well as the head-unit, which is usually placed in or
-above the center stack where one normally had just a radio back in the days.
+PELUX is an agnostic reference integration platform for building automotive
+Linux-based systems, e.g. In-Vehicle Infotainment (IVI) systems. IVI systems
+are usually responsible for everything shown in the dashboard of the car as
+well as the head-unit, which is usually placed in or above the center stack
+where one normally had just a radio back in the days.
 
 IVI systems are obviously put into cars by its car maker. However, most car
 makers do not develop the software for these systems in-house, but they contract
@@ -46,8 +48,8 @@ automotive grade hardware arises, it can be easily modified to work with that
 hardware.
 
 PELUX being open-source together with readily-available instructions in this
-Software Factory, a car maker, or any interested individual, can experiment with
-the system, build prototypes or simply download and run it.
+handbook, a car maker, or any interested individual, can experiment with the
+system, build prototypes or simply download and run it.
 
 
 .. _pelux.io: https://pelux.io
@@ -55,24 +57,24 @@ the system, build prototypes or simply download and run it.
 -------------------
 
 .. toctree::
+    :caption: Table of contents
+    :maxdepth: 2
+
+    chapters/architecture/index
+    chapters/baseplatform/index
+    chapters/ci-and-cd/index
+    chapters/workflow/git/index
+    chapters/sdk/index
+    chapters/sde/index
+    swf-blueprint/docs/articles/templates/index
+    swf-blueprint/docs/articles/licensing/index
+    chapters/workflow/release/index
+
+.. toctree::
     :caption: About
     :maxdepth: 2
 
     swf-blueprint/docs/articles/intro/index.rst
-
-.. toctree::
-    :caption: Table of contents
-    :maxdepth: 2
-
-    chapters/workflow/git/index
-    chapters/baseplatform/index
-    chapters/ci-and-cd/index
-    chapters/sdk/index
-    chapters/sde/index
-    chapters/architecture/index
-    swf-blueprint/docs/articles/templates/index
-    swf-blueprint/docs/articles/licensing/index
-    chapters/workflow/release/index
 
 .. toctree::
     :caption: Categories


### PR DESCRIPTION
The term Software Factory is from now on referred to Luxoft
Software Factory and PELUX Software Factory is from now on
referred to the PELUX Development Handbook.

The handbook contains blueprints and processes and can be
considered to be part of or to be an instance of the Luxoft
Software Factory.

The landing page has also been restructured.