### PR TITLE
Custom sphinx theme

### DIFF
--- a/docs/chapters/architecture/subsystems/SOTA/SOTA-system.rst
+++ b/docs/chapters/architecture/subsystems/SOTA/SOTA-system.rst
@@ -388,7 +388,7 @@ The developers of SWUpdate also provide a meta-swupdate-boards layer with
 example recipes on how to integrate SWUpdate to a couple of platforms. Most of
 the code in this layer is irrelevant to us since it refers to a demo
 "core-image-full-cmdline" image and to platforms such as the wandboard or
-beaglebone which aren't supported by PELUX.
+beaglebone which are not supported by PELUX.
 
 meta-swupdate has been integrated to the default PELUX manifests, to avoid code
 duplication. However, it has been decided that the meta-swupdate-boards

--- a/docs/chapters/architecture/subsystems/SOTA/getting-started-SOTA.rst
+++ b/docs/chapters/architecture/subsystems/SOTA/getting-started-SOTA.rst
@@ -49,7 +49,7 @@ We will fetch Hawkbit from its GitHub repository.
     $ git clone https://github.com/eclipse/hawkbit
     $ cd hawkbit
 
-Recent versions of Hawkbit aren't yet supported by SWUpdate so we need to
+Recent versions of Hawkbit are not yet supported by SWUpdate so we need to
 manually select a slightly older version of Hawkbit.
 
 .. code-block:: bash

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -133,8 +133,15 @@ html_theme_options = {
     'head_font_family': 'Roboto, Helvetica, Arial, sans-serif',
     'font_size': '16px',
 
+    # Project info
+    'logo': 'logo.png',
+    'logo_name': 'true',
+
     # Navigation
-    'sidebar_collapse': 'false'
+    'show_related': 'true',
+    'sidebar_includehidden': 'true',
+    'sidebar_collapse': 'false',
+    'fixed_sidebar': 'true'
     #'show_relbars': 'true' #Not working option
 
 }

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -125,7 +125,19 @@ actdiag_html_image_format = "SVG"
 # - https://github.com/snide/sphinx_rtd_theme
 # - https://pypi.python.org/pypi/sphinx_rtd_theme
 # - python-sphinx-rtd-theme package (on Debian)
-html_theme = "sphinx_rtd_theme"
+html_theme = "alabaster"
+
+html_theme_options = {
+    # Fonts
+    'font_family': 'Roboto, Helvetica, Arial, sans-serif',
+    'head_font_family': 'Roboto, Helvetica, Arial, sans-serif',
+    'font_size': '16px',
+
+    # Navigation
+    'sidebar_collapse': 'false'
+    #'show_relbars': 'true' #Not working option
+
+}
 
 # html_logo = None
 # html_favicon = None

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,8 +54,11 @@ system, build prototypes or simply download and run it.
 
 -------------------
 
+Table of Contents
+*****************
+
 .. toctree::
-    :caption: Table of contents
+    :caption: PELUX Development Handbook
     :maxdepth: 2
 
     chapters/architecture/index


### PR DESCRIPTION
Customize the Alabaster theme to get a common look-and-feel with pelux.io.

TBD: Add a header with links to homepage (if possible).