### PR TITLE
conf.py.in: set canonical_url

### DIFF
--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -184,3 +184,7 @@ texinfo_documents = [
      author, '@PROJECT_NAME@', 'One line description of project.',
      'Miscellaneous'),
 ]
+
+html_theme_options = {
+    'canonical_url': 'https://pelux.io/software-factory/master/',
+}


### PR DESCRIPTION
This specifies a canonical URL meta link element to tell search engines
which URL should be ranked as the primary URL for the documentation.

This is important since we have multiple URLs that software-factory is
available through due to its versioning, e.g. /2.0/, /3.0/...

Fixes #120.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>