### PR TITLE
Add instructions for putting images onto the ARP

### DIFF
--- a/docs/chapters/baseplatform/booting-on-target-hardware.rst
+++ b/docs/chapters/baseplatform/booting-on-target-hardware.rst
@@ -2,6 +2,21 @@ Booting on target hardware
 ==========================
 .. note:: Login as user ``root``.
 
+ARP
+---
+
+On the ARP there are three options available for booting:
+
+1. USB: Boot from a USB-stick by simply inserting said USB-stick into one of the
+   USB ports on the ARP. Make sure that USB is set as boot source in BIOS/u-boot
+2. SD-card: Insert the SD-card into the slot labeled "SMARC SD" located next
+   to the USB ports. This feature requires ARP version >= 1.5.
+3. EMMC: On most SMARC devices there is an EMMC which can be used for booting.
+   This is the boot option with best performance. However, it requires some
+   setup to get the PELUX image on to the EMMC. An example of such a setup would
+   be putting the image in question on to a USB-stick with containing Ubuntu-live,
+   boot into the Ubuntu live mode and use `dd` to write the image onto the EMMC.
+
 NUC
 ---
 

--- a/docs/chapters/baseplatform/deploying-the-image.rst
+++ b/docs/chapters/baseplatform/deploying-the-image.rst
@@ -3,5 +3,5 @@
 
 Image names for PELUX targets
 -----------------------------
-* NUC/Minnowboard: ``core-image-pelux-intel-corei7-64.wic``
+* NUC, Minnowboard and ARP with Intel SMARC: ``core-image-pelux-intel-corei7-64.wic``
 * Raspberry Pi 3: ``core-image-pelux-raspberrypi3.rpi-sdimg``


### PR DESCRIPTION
Add instructions for putting PELUX images on to the ARP. This includes the
booting from USB, SD-card and EMMC.

The instructions focus on the ARP as an intel target so some information.
Meaning that if PELUX at a later stage decides to support other SMARC
modules, such as ARM based SMARC modules, then additional information
might need to be added.

Signed-off-by: Viktor Sjölind <vsjolind@luxoft.com>