### PR TITLE
building-PELUX-sources: remove image table

### DIFF
--- a/docs/chapters/baseplatform/building-PELUX-sources.rst
+++ b/docs/chapters/baseplatform/building-PELUX-sources.rst
@@ -2,18 +2,33 @@
 
 .. _building-pelux-sources:
 
-Building PELUX sources
-======================
+Building PELUX
+==============
 
-This chapter details how to download and configure the sources of a PELUX build, so
-that an image can be built.
+Pelux is build on top of multiple sources, they are described on an ``xml`` file called ``pelux.xml``. 
+In order to clone all the sources at once, ``repo`` is used.
 
-A note on development images
-----------------------------
-Both PELUX images are available as `-dev` variants, which include some extra
-development and debugging tools. For some platforms, those images are also
-available as `-update` to generate update artifacts for the :ref:`SOTA
-System<getting-started-sota>`.
+Fetching sources
+----------------
+
+Create a directory for the PELUX build. On that directory, run ``repo init``, and it will create a ``.repo`` directory which will later be used for fetching the sources.
+Run ``repo sync`` to fetch all sources on a new directory called sources.
+
+.. code-block:: bash
+
+    # Initialize repo on the given repository
+    repo init -u https://github.com/Pelagicore/pelux-manifests.git
+
+    #Fetch the sources based on the .repo directory
+    repo sync
+
+Now all the repositories required for building PELUX have been cloned under ``sources/`` directory. 
+
+A note on image types
+---------------------
+PELUX images are available with the `-dev` suffix, which include some extra
+development and debugging tools. Images are also available as `-update` to generate update artifacts for the :ref:`SOTA
+System<getting-started-sota>`. The `-dev` and `-update` images can also be merged to build `-dev-update` which includes both features on the image. 
 
 It should be noted that the regular image is *not* a production ready image. For
 a production project, it is recommended to create an image that can be based on
@@ -22,76 +37,100 @@ image eventually, as the project evolves further and further away from vanilla
 PELUX. For example, a PELUX-based image has an empty root password and an ssh
 server installed by default.
 
-Building locally
-----------------
+Image variants
+--------------
+Pelux can be build for `intel`, `arp`, `rpi`, and `qemu`. Our variants are dependent on the target we are building for.
+If the variant contains only the target, a minimal image will be available to be built with no graphics layer. If the variant contains the target name, and the suffix ``-qtauto``, the minimal image will be available to be build as well as the image containing Qt Automotive.
 
-Create a directory for the PELUX build. Instruct repo tool to fetch a manifest
-using the command `repo init`. In this context, branch denotes what branch of the
-git repo `pelux-manifests` to use. If you want to use a released version of
-PELUX, use the SHA id of the commit pointed to by the release tag (or the branch
-that the commit lies on). Otherwise, ``master`` is usually a good choice for
-cutting-edge.
+The only variant which does not offer a graphical UI is QEMU. 
 
-Then make repo tool fetch all sources using the command `repo sync`.
+All the variants set different configurations, therefore it is important to specify the correct variant before sourcing for bitbake. 
+
+**Intel variants**
+
+- intel
+- intel-qtauto
+
+**RaspberryPi variants**
+
+- rpi
+- rpi-qtauto
+
+**ARP variants**
+
+- arp
+- arp-qtauto
+
+**QEMU variants**
+
+- qemu-x86-64_nogfx
+
+When sourcing, you can tell the ``oe-init-build-dev`` script, to use a specific directory for configuration of a variant.
+
+``TEMPLATECONF`` tells the ``oe-init-build-env`` script which path to fetch
+configuration samples from.
 
 .. code-block:: bash
 
-    mkdir pelux
-    cd pelux
-    repo init -u https://github.com/Pelagicore/pelux-manifests.git -b <branch>
-    repo sync
+    TEMPLATECONF=`pwd`/sources/meta-pelux/conf/variant/<VARIANT-NAME> source sources/poky/oe-init-build-env build
+
+
+The script will create configurations if there are no configurations present. A printout about
+creating ``conf/local.conf`` and ``conf/bblayers.conf`` is normal.
+
 
 .. _building-pelux-sources-available-images:
 
 Available images
 ^^^^^^^^^^^^^^^^
+We support intel, ARP and raspberry pi builds. The qt-auto layer can be found on all of them. 
 
-.. This is to get red and green colours for the symbols below
-.. role:: available
-.. role:: unavailable
-.. raw:: html
-
-    <!-- The roles we defined in rst will translate to style sheet classes -->
-    <style> .available {color:green} .unavailable {color:red} </style>
-
-+--------------------------------------------+------------------+------------------+------------------+----------------+
-|                                            |      Variant name                                                       |
-+          Image name                        +------------------+------------------+------------------+----------------+
-|                                            | intel            | intel-qtauto     | rpi              | rpi-qtauto     |
-+============================================+==================+==================+==================+================+
-| core-image-pelux-minimal                   | :available:`✔`   | :available:`✔`   | :available:`✔`   | :available:`✔` |
-+--------------------------------------------+------------------+------------------+------------------+----------------+
-| core-image-pelux-minimal-dev               | :available:`✔`   | :available:`✔`   | :available:`✔`   | :available:`✔` |
-+--------------------------------------------+------------------+------------------+------------------+----------------+
-| core-image-pelux-qtauto-neptune            | :unavailable:`✘` | :available:`✔`   | :unavailable:`✘` | :available:`✔` |
-+--------------------------------------------+------------------+------------------+------------------+----------------+
-| core-image-pelux-qtauto-neptune-dev        | :unavailable:`✘` | :available:`✔`   | :unavailable:`✘` | :available:`✔` |
-+--------------------------------------------+------------------+------------------+------------------+----------------+
-| core-image-pelux-minimal-update            | :available:`✔`   | :available:`✔`   | :available:`✔`   | :available:`✔` |
-+--------------------------------------------+------------------+------------------+------------------+----------------+
-| core-image-pelux-minimal-dev-update        | :available:`✔`   | :available:`✔`   | :available:`✔`   | :available:`✔` |
-+--------------------------------------------+------------------+------------------+------------------+----------------+
-| core-image-pelux-qtauto-neptune-update     | :unavailable:`✘` | :available:`✔`   | :unavailable:`✘` | :available:`✔` |
-+--------------------------------------------+------------------+------------------+------------------+----------------+
-| core-image-pelux-qtauto-neptune-dev-update | :unavailable:`✘` | :available:`✔`   | :unavailable:`✘` | :available:`✔` |
-+--------------------------------------------+------------------+------------------+------------------+----------------+
-
-When done fetching the sources, create a build directory and set up bitbake.
-``TEMPLATECONF`` tells the ``oe-init-build-env`` script which path to fetch
-configuration samples from.
-
-.. note:: The example below gets the template configuration for the Intel BSP
-          without Qt Automotive Suite (QtAS). Use ``intel-qtauto`` as the last
-          part of the path to get QtAS support. The same pattern is used for the
-          Raspberry Pi BSP (``rpi`` and ``rpi-qtauto``). There is also
-          experimental support for ``qemu-x86-64-nogfx``.
+Once you have synced the repo, run the following to configure the environment for Qt Automotive images. 
 
 .. code-block:: bash
 
-    TEMPLATECONF=`pwd`/sources/meta-pelux/conf/variant/intel source sources/poky/oe-init-build-env build
+    # For intel-qtauto:
+    TEMPLATECONF=`pwd`/sources/meta-pelux/conf/variant/intel-qtauto source sources/poky/oe-init-build-env build
+    # For rpi-qtauto:
+    TEMPLATECONF=`pwd`/sources/meta-pelux/conf/variant/rpi-qtauto source sources/poky/oe-init-build-env build
+    # For arp-qtauto:
+    TEMPLATECONF=`pwd`/sources/meta-pelux/conf/variant/arp-qtauto source sources/poky/oe-init-build-env build
 
-The script will create configurations if there are no configurations present. A printout about
-creating ``conf/local.conf`` and ``conf/bblayers.conf`` is normal.
+For ``arp-qtauto``, ``intel-qtauto`` and ``rpi-qtauto`` variants, we support the following images: 
+
+Minimal Images
+""""""""""""""
+* core-image-pelux-minimal  
+* core-image-pelux-minimal-dev
+* core-image-pelux-minimal-update 
+* core-image-pelux-minimal-dev-update 
+
+Qt Automotive + Neptune 3 UI images
+"""""""""""""""""""""""""""""""""""
+* core-image-pelux-qtauto-neptune
+* core-image-pelux-qtauto-neptune-dev
+* core-image-pelux-qtauto-neptune-update
+* core-image-pelux-qtauto-neptune-dev-update
+
+In case you want to build only the pelux base image, that can be done by removing `qtauto` suffix from the variant name.
+
+.. code-block:: bash
+
+    # For intel: 
+    TEMPLATECONF=`pwd`/sources/meta-pelux/conf/variant/intel source sources/poky/oe-init-build-env build
+    # For rpi:
+    TEMPLATECONF=`pwd`/sources/meta-pelux/conf/variant/rpi source sources/poky/oe-init-build-env build
+    # For arp:
+    TEMPLATECONF=`pwd`/sources/meta-pelux/conf/variant/arp source sources/poky/oe-init-build-env build
+
+For ``arp``, ``intel`` and ``rpi`` variants, we support the following images: 
+
+Minimal images
+""""""""""""""
+* core-image-pelux-minimal  
+* core-image-pelux-minimal-dev
+* core-image-pelux-minimal-update 
+* core-image-pelux-minimal-dev-update 
 
 Building the image
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The image table is hard to be read and often very confusing, this will
simplify it for new users.

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>