### PR TITLE
release-process: mention compressed wic images and bmap files in list of artifacts

### DIFF
--- a/docs/chapters/workflow/release/release-process.rst
+++ b/docs/chapters/workflow/release/release-process.rst
@@ -71,7 +71,8 @@ List of artifacts
     - Instructions or pointers to instructions that have changed as a result of
       the changes since last release.
     - This list of artifacts.
-- Binary Wic images of all the variants for all the supported platforms.
+- Compressed Binary Wic bz2 images of all the variants for all the supported
+  platforms and corresponding bmap files.
 - The source code of all the packages that are included in the released images.
 - SDK installers for all the supported hardware platforms.
 


### PR DESCRIPTION
The size of the wic files almost doubled in size when we added software update and now we also have a /data partition (almost +1GB). An uncompressed Intel QtAuto wic image is currently 7.83GB while a bz2 compressed one is 1.23GB.

Including .bmap files in the release means it will also be much faster to flash. We already have instructions in the handbook for how to use them.